### PR TITLE
Fix typo in one of 'setup_test' tests

### DIFF
--- a/setup_test.go
+++ b/setup_test.go
@@ -31,7 +31,7 @@ func TestParseStanza(t *testing.T) {
 			fall.Zero,
 		},
 		{
-			`kubernetes coredns.local clusterset.local {
+			`multicluster coredns.local clusterset.local {
     fallthrough
 }`,
 			false,


### PR DESCRIPTION
Fix typo in plugin name in one of the tests,
changed plugin name in the test from 'kubernetes' to 'multicluster'

Signed-off-by: Itay nakash <itaynaka@gmail.com>