### PR TITLE
Use tickers instead of time.After to avoid memory leak

### DIFF
--- a/multicluster.go
+++ b/multicluster.go
@@ -86,18 +86,24 @@ func (m *MultiCluster) InitController(ctx context.Context) (onStart func() error
 			m.controller.Run()
 		}()
 
-		timeout := time.After(5 * time.Second)
-		ticker := time.NewTicker(100 * time.Millisecond)
-		defer ticker.Stop()
+		timeout := 5 * time.Second
+		timeoutTicker := time.NewTicker(timeout)
+		defer timeoutTicker.Stop()
+		logDelay := 500 * time.Millisecond
+		logTicker := time.NewTicker(logDelay)
+		defer logTicker.Stop()
+		checkSyncTicker := time.NewTicker(100 * time.Millisecond)
+		defer checkSyncTicker.Stop()
 		for {
 			select {
-			case <-ticker.C:
+			case <-checkSyncTicker.C:
 				if m.controller.HasSynced() {
 					return nil
 				}
-			case <-timeout:
-				log.Warning("starting server with unsynced Kubernetes API")
-				return nil
+			case <-logTicker.C:
+				log.Info("waiting for Kubernetes API before starting server multicluster")
+			case <-timeoutTicker.C:
+				log.Warning("starting server multicluster with unsynced Kubernetes API")
 			}
 		}
 	}


### PR DESCRIPTION
This apply similar fixes to this fixes applied to many coredns plugins https://github.com/coredns/coredns/commit/967814161aafca87434d61bac02d95794d2549af and the associated followup fix: https://github.com/coredns/coredns/commit/c02cd52208d53cba0fb0498b6ecad50f78a4333d