### PR TITLE
Fix error NXDOMAIN for TXT lookups

### DIFF
--- a/multicluster.go
+++ b/multicluster.go
@@ -193,15 +193,23 @@ func (m MultiCluster) Services(ctx context.Context, state request.Request, exact
 		// 1 label + zone, label must be "dns-version".
 		t, _ := dnsutil.TrimZone(state.Name(), state.Zone)
 
+		// Hard code the only valid TXT - "dns-version.<zone>"
 		segs := dns.SplitDomainName(t)
-		if len(segs) != 1 {
+		if len(segs) == 1 && segs[0] == "dns-version" {
+			svc := msg.Service{Text: DNSSchemaVersion, TTL: 28800, Key: msg.Path(state.QName(), coredns)}
+			return []msg.Service{svc}, nil
+		}
+
+		// Check if we have an existing record for this query of another type
+		services, _ := m.Records(ctx, state, false)
+
+		if len(services) > 0 {
+			// If so we return an empty NOERROR
 			return nil, nil
 		}
-		if segs[0] != "dns-version" {
-			return nil, nil
-		}
-		svc := msg.Service{Text: DNSSchemaVersion, TTL: 28800, Key: msg.Path(state.QName(), coredns)}
-		return []msg.Service{svc}, nil
+
+		// Return NXDOMAIN for no match
+		return nil, errNoItems
 
 		// TODO support TypeNS
 	}

--- a/multicluster_handler_test.go
+++ b/multicluster_handler_test.go
@@ -231,6 +231,22 @@ var dnsTestCases = []test.Case{
 			test.TXT("dns-version.cluster.local 28800 IN TXT 1.1.0"),
 		},
 	},
+	// A TXT record does not exist but another record for the same FQDN does
+	{
+		Qname: "svc1.testns.svc.cluster.local.", Qtype: dns.TypeTXT,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.        5        IN        SOA        ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	// A TXT record does not exist and neither does another record for the same FQDN
+	{
+		Qname: "svc0.svc-nons.svc.cluster.local.", Qtype: dns.TypeTXT,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.        5        IN        SOA        ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
 	// A Service (Headless) does not exist
 	{
 		Qname: "bogusendpoint.clusterid.hdls1.testns.svc.cluster.local.", Qtype: dns.TypeA,


### PR DESCRIPTION
Apply similar fixes done to the kubernetes plugin in coredns: https://github.com/coredns/coredns/commit/c3228615e071de61b0c6f60d9a231c494726dda0