### PR TITLE
add test to make sure querying endpoints from a service is not allowed

### DIFF
--- a/multicluster_handler_test.go
+++ b/multicluster_handler_test.go
@@ -147,6 +147,14 @@ var dnsTestCases = []test.Case{
 			test.A("dup-name.clusterid.hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.5"),
 		},
 	},
+	// Querying endpoints from a specific clusters it not allowed without specifying the hostname
+	{
+		Qname: "clusterid.hdls1.testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
 	// SRV Service (Headless)
 	{
 		Qname: "_http._tcp.hdls1.testns.svc.cluster.local.", Qtype: dns.TypeSRV,


### PR DESCRIPTION
As this type of query is not allowed we make sure it actually is with a new test.

Quoting the MCS-API KEP with the explanation of why this is not allowed: While we reserve the form <clusterid>.<svc>.<ns>.svc.clusterset.local. for possible future use, both ClusterSetIP Services and Multicluster Headless Services are specified to explicitly disallow using this form to create DNS records that target all 1+N backends in a specific cluster.