### PR TITLE
object: fix object cleanup

### DIFF
--- a/object/endpoint.go
+++ b/object/endpoint.go
@@ -1,6 +1,8 @@
 package object
 
 import (
+	"maps"
+
 	"github.com/coredns/coredns/plugin/kubernetes/object"
 	mcs "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
@@ -20,11 +22,11 @@ func EndpointsKey(name, namespace string) string { return name + "." + namespace
 
 // EndpointSliceToEndpoints converts a *discovery.EndpointSlice to a *Endpoints.
 func EndpointSliceToEndpoints(obj meta.Object) (meta.Object, error) {
+	labels := maps.Clone(obj.GetLabels())
 	ends, err := object.EndpointSliceToEndpoints(obj)
 	if err != nil {
 		return nil, err
 	}
-	labels := obj.GetLabels()
 	e := &Endpoints{
 		Endpoints: *ends.(*object.Endpoints),
 		ClusterId: labels[mcs.LabelSourceCluster],

--- a/object/serviceimport.go
+++ b/object/serviceimport.go
@@ -50,6 +50,7 @@ func ToServiceImport(obj meta.Object) (meta.Object, error) {
 		copy(s.Ports, svc.Spec.Ports)
 	}
 
+	*svc = mcs.ServiceImport{}
 	return s, nil
 }
 


### PR DESCRIPTION
This commit add object cleanup to be consistent with similar code in the kubernetes plugin.

It also does a clone of the EndpointSlice labels so that it's not erased by the function `EndpointSliceToEndpoints` from the kubernetes plugin fixing an important bug in the multicluster code as it was previously not able to retrieve any labels which essentially prevented any interaction with headless services.